### PR TITLE
Make the library compile on stable Rust 1.8

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,5 @@
 //! Parser for bitmap fonts
 
-#![feature(unicode)]
-
 mod char;
 mod config_parse_error;
 mod error;
@@ -163,9 +161,8 @@ impl BMFont {
                 unsupported_characters.push(c);
                 continue;
             }
-            let mut buffer: [u16; 4] = [0, 0, 0, 0];
-            c.encode_utf16(&mut buffer).unwrap();
-            let char_id = buffer[0] as u32;
+            let tmp_str = { let mut t = String::new(); t.push(c); t };
+            let char_id = tmp_str.encode_utf16().next().unwrap() as u32;
             if let Some(c) = self.characters.iter().find(|c| c.id == char_id) {
                 line.push(c);
             } else {


### PR DESCRIPTION
The crate was no longer compiling because of a change in `encode_utf16`'s API. This PR fixes it and also makes the library compile on stable Rust.

Unfortunately this means that we needs to build a temporary String, because `encode_utf16` isn't stable on `char` yet. But I think the benefits outweigh the drawbacks.

If you merge this, could you please also publish a new version on crates.io?
