### PR TITLE
Fix for missing "kerning" sections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ exclude = [
 ]
 
 [dev-dependencies]
-glium = "0.13"
-image = "0.6"
+glium = "^0.16.0"
+image = "^0.10.3"
 

--- a/src/sections.rs
+++ b/src/sections.rs
@@ -13,18 +13,23 @@ impl Sections {
     pub fn new<R>(mut source: R) -> Result<Sections, Error>
         where R: Read
     {
+        // Load the entire file into a String.
         let mut content = String::new();
         try!(source.read_to_string(&mut content));
+
+        // Expect the "info" section.
         let mut lines = content.lines();
         if !lines.next().map(|l| l.starts_with("info")).unwrap_or(false) {
             return Err(Error::from(ConfigParseError::MissingSection(String::from("info"))));
         }
 
+        // Expect the "common" section.
         let common_section = match lines.next() {
             Some(line) if line.starts_with("common") => line.to_owned(),
             _ => return Err(Error::from(ConfigParseError::MissingSection(String::from("common"))))
         };
 
+        // Expect the "page" sections.
         let lines = lines.skip_while(|l| !l.starts_with("page"))
                          .collect::<Vec<_>>();
         let lines = lines.iter();
@@ -36,6 +41,8 @@ impl Sections {
             return Err(Error::from(ConfigParseError::MissingSection(String::from("page"))));
         }
         let mut lines = lines.skip(page_sections.len());
+
+        // Expect the "char" sections.
         let _ = lines.next().unwrap(); // char_count_section
         let char_sections = lines.clone()
                                  .take_while(|l| l.starts_with("char"))
@@ -45,11 +52,17 @@ impl Sections {
             return Err(Error::from(ConfigParseError::MissingSection(String::from("char"))));
         }
         let mut lines = lines.skip(char_sections.len());
-        let _ = lines.next().unwrap(); // kerning_count_section
-        let kerning_sections = lines.clone()
-                                    .take_while(|l| l.starts_with("kerning"))
-                                    .map(|s| s.to_string())
-                                    .collect::<Vec<_>>();
+
+        // Expect the "kerning" sections.
+        let kerning_sections = if let Some(_) = lines.next() {
+            lines.clone()
+                 .take_while(|l| l.starts_with("kerning"))
+                 .map(|s| s.to_string())
+                 .collect::<Vec<_>>()
+        } else {
+            Vec::new()
+        };
+
         Ok(Sections {
             common_section: common_section,
             page_sections: page_sections,


### PR DESCRIPTION
For users of AngelCodes' BMFont program this small fix makes it possible to use fonts where there is no kerning section. See the [documentation](http://www.angelcode.com/products/bmfont/doc/file_format.html):
> This block is only in the file if there are any kerning pairs with amount differing from 0.