### PR TITLE
Benchmarking and iterator pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bmfont"
+edition = "2018"
 version = "0.3.1"
 authors = ["kalita.alexey <kalita.alexey@outlook.com>"]
 description = "bitmap font config parser"
@@ -15,5 +16,10 @@ exclude = [
 ]
 
 [dev-dependencies]
+criterion = "0.3"
 glium = "^0.16.0"
 image = "^0.10.3"
+
+[[bench]]
+name = "parse"
+harness = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ criterion = "0.3"
 glium = "^0.16.0"
 image = "^0.10.3"
 
+[features]
+default = ["parse-error"]
+parse-error = []
+
 [[bench]]
 name = "parse"
 harness = false

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ Bitmap font config parser implemented in Rust
 # Contributing
 Library lacks documentation. I am not good at it. If you are then you are welcome to contribute new documentation.
 
+## Optional features
+
+* `parse-error` *(enabled by default)* -
+  [`BMFont::parse()`](https://docs.rs/bmfont-rust/latest/bmfont/struct.BMFont.html#method.parse)
+  returns missing and unsupported characters.
+
 ## License
 
 Licensed under either of

--- a/benches/README.md
+++ b/benches/README.md
@@ -1,0 +1,7 @@
+# Benchmarking BMFont
+
+In the root BMFont project directory:
+
+```bash
+cargo bench
+```

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -9,9 +9,9 @@ const INPUTS: &[(&str, &str)] = &[
     ("02: Character", "w"),
     ("03: Word", "Score"),
     ("04: Pair", "Winner: Attackgoat"),
-    ("05: Sentance", "The lazy dog can sit wherever she wishes."),
+    ("05: Sentence", "The lazy dog can sit wherever she wishes."),
     ("06: Two lines", "Where is her sweater?\nIt's not in her car."),
-    ("07: Long sentance", "The acquisition of wealth is no longer the driving force of our lives. We work to better ourselves and the rest of humanity."),
+    ("07: Long sentence", "The acquisition of wealth is no longer the driving force of our lives. We work to better ourselves and the rest of humanity."),
     ("08: Two long lines", "Someone once told me that time was a predator that stalked us all our lives. I rather believe that time is a\ncompanion who goes with us on the journey and reminds us to cherish every moment, because it will never come again. What we leave behind is not as important as how we've lived."),
     ("09: Lyrics", "Van Gogh my earlobe\nI can't hear, I'm here though\nI may be a weirdo, but this is my year, yo\nMy life may be crazy\nMy lack of the lazy has let me write code that I love on the daily.\nVan Gogh my earlobe\nI can't hear, I'm here though\nI may be a weirdo, but this is my year, yo\nMy life may be crazy\nMy lack of the lazy has let me write code that I love on the daily.\nVan Gogh my earlobe\nI can't hear, I'm here though\nI may be a weirdo, but this is my year, yo\nMy life may be crazy\nMy lack of the lazy has let me write code that I love on the daily."),
 ];

--- a/benches/parse.rs
+++ b/benches/parse.rs
@@ -1,0 +1,31 @@
+use {
+    bmfont::*,
+    criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion},
+    std::fs::File,
+};
+
+const INPUTS: &[(&str, &str)] = &[
+    ("01: Empty", ""),
+    ("02: Character", "w"),
+    ("03: Word", "Score"),
+    ("04: Pair", "Winner: Attackgoat"),
+    ("05: Sentance", "The lazy dog can sit wherever she wishes."),
+    ("06: Two lines", "Where is her sweater?\nIt's not in her car."),
+    ("07: Long sentance", "The acquisition of wealth is no longer the driving force of our lives. We work to better ourselves and the rest of humanity."),
+    ("08: Two long lines", "Someone once told me that time was a predator that stalked us all our lives. I rather believe that time is a\ncompanion who goes with us on the journey and reminds us to cherish every moment, because it will never come again. What we leave behind is not as important as how we've lived."),
+    ("09: Lyrics", "Van Gogh my earlobe\nI can't hear, I'm here though\nI may be a weirdo, but this is my year, yo\nMy life may be crazy\nMy lack of the lazy has let me write code that I love on the daily.\nVan Gogh my earlobe\nI can't hear, I'm here though\nI may be a weirdo, but this is my year, yo\nMy life may be crazy\nMy lack of the lazy has let me write code that I love on the daily.\nVan Gogh my earlobe\nI can't hear, I'm here though\nI may be a weirdo, but this is my year, yo\nMy life may be crazy\nMy lack of the lazy has let me write code that I love on the daily."),
+];
+
+fn parse(c: &mut Criterion) {
+    let file = File::open("font.fnt").unwrap();
+    let font = BMFont::new(file, OrdinateOrientation::TopToBottom).unwrap();
+    let mut group = c.benchmark_group("Parse");
+    for (desc, input) in INPUTS.iter() {
+        group.bench_with_input(BenchmarkId::new("Input", desc), input, |b, input| {
+            b.iter(|| font.parse(black_box(input)))
+        });
+    }
+}
+
+criterion_group!(benches, parse);
+criterion_main!(benches);

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -60,7 +60,11 @@ fn main() {
         OrdinateOrientation::BottomToTop,
     )
     .unwrap();
-    let char_positions = bmfont.parse("Hello\nmy\nfriend").unwrap();
+    let char_positions = bmfont.parse("Hello\nmy\nfriend");
+
+    #[cfg(feature = "parse-error")]
+    let char_positions = char_positions.unwrap();
+
     let shapes = char_positions.into_iter().map(|char_position| {
         let left_page_x = char_position.page_rect.x as f32 / image_dimensions.0 as f32;
         let right_page_x = char_position.page_rect.max_x() as f32 / image_dimensions.0 as f32;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,8 +134,8 @@ impl BMFont {
     /// #     Ok(())
     /// # }
     /// ```
-    pub fn pages(&self) -> impl Iterator<Item = &str> {
-        self.pages.iter().map(|p| p.file.as_str())
+    pub fn pages(&self) -> PageIter {
+        PageIter::new(&self.pages)
     }
 
     pub fn parse(&self, s: &str) -> Result<Vec<CharPosition>, StringParseError> {
@@ -231,6 +231,34 @@ impl BMFont {
                 missing_characters,
                 unsupported_characters,
             })
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PageIter<'a> {
+    idx: usize,
+    pages: &'a Vec<Page>,
+}
+
+impl<'a> PageIter<'a> {
+    fn new(pages: &'a Vec<Page>) -> Self {
+        Self {
+            idx: 0,
+            pages: &*pages,
+        }
+    }
+}
+
+impl<'a> Iterator for PageIter<'a> {
+    type Item = &'a str;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(page) = self.pages.get(self.idx) {
+            self.idx += 1;
+            Some(page.file.as_str())
+        } else {
+            None
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ pub struct BMFont {
 impl BMFont {
     /// Constructs a new [BMFont].
     ///
-    /// ## Examples
+    /// # Examples
     ///
     /// From a file:
     ///
@@ -164,7 +164,7 @@ impl BMFont {
 
     /// Returns an `Iterator` of font page bitmap filenames.
     ///
-    /// ## Examples
+    /// # Examples
     ///
     /// ```rust
     /// # use bmfont::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,8 +92,21 @@ impl BMFont {
         self.line_height
     }
 
-    pub fn pages(&self) -> Vec<String> {
-        self.pages.iter().map(|p| p.file.clone()).collect()
+    /// Returns an `Iterator` of font page bitmap filenames.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// # use bmfont::*;
+    /// # fn main() -> Result<(), Error> {
+    /// let file = std::fs::File::open("font.fnt")?;
+    /// let font = BMFont::new(file, OrdinateOrientation::TopToBottom)?;
+    /// assert_eq!(font.pages().next(), Some("font.png"));
+    /// #     Ok(())
+    /// # }
+    /// ```
+    pub fn pages(&self) -> impl Iterator<Item = &str> {
+        self.pages.iter().map(|p| p.file.as_str())
     }
 
     pub fn parse(&self, s: &str) -> Result<Vec<CharPosition>, StringParseError> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub enum OrdinateOrientation {
     TopToBottom,
 }
 
+/// Holds a decoded bitmap font defintion, including all character advance and kerning values.
 #[derive(Clone, Debug)]
 pub struct BMFont {
     base_height: u32,
@@ -45,6 +46,34 @@ pub struct BMFont {
 }
 
 impl BMFont {
+    /// Constructs a new [BMFont].
+    ///
+    /// ## Examples
+    ///
+    /// From a file:
+    ///
+    /// ```rust
+    /// # use bmfont::*;
+    /// # fn main() -> Result<(), Error> {
+    /// let file = std::fs::File::open("font.fnt")?;
+    /// let font = BMFont::new(file, OrdinateOrientation::TopToBottom)?;
+    /// assert_eq!(font.line_height(), 80);
+    /// #     Ok(())
+    /// # }
+    /// ```
+    ///
+    /// From a slice of bytes:
+    ///
+    /// ```rust
+    /// # use bmfont::*;
+    /// # fn main() -> Result<(), Error> {
+    /// # let my_font_bytes = std::fs::read("font.fnt")?;
+    /// let data = std::io::Cursor::new(my_font_bytes);
+    /// let font = BMFont::new(data, OrdinateOrientation::TopToBottom)?;
+    /// assert_eq!(font.line_height(), 80);
+    /// #     Ok(())
+    /// # }
+    /// ```
     pub fn new<R>(source: R, ordinate_orientation: OrdinateOrientation) -> Result<BMFont, Error>
     where
         R: Read,

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -263,7 +263,7 @@ fn assert_letters_with_kerning_parsed_correctly(orientation: OrdinateOrientation
 #[test]
 fn pages_parsed_correctly() {
     let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
-    assert_eq!(bmfont.pages(), vec![String::from("font.png")]);
+    assert_eq!(bmfont.pages().next(), Some("font.png"));
 }
 
 #[test]

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,12 +13,13 @@ fn create_bmfont(ordinate_orientation: OrdinateOrientation) -> BMFont {
 }
 
 fn parse(s: &str, ordinate_orientation: OrdinateOrientation) -> Vec<CharPosition> {
-    let font = create_bmfont(ordinate_orientation).parse(s);
+    let font = create_bmfont(ordinate_orientation);
+    let parse = font.parse(s);
 
     #[cfg(feature = "parse-error")]
-    let font = font.unwrap();
+    let parse = parse.unwrap();
 
-    font
+    parse.collect()
 }
 
 fn assert_rect_equal(rect: &Rect, another_rect: &Rect) {
@@ -315,7 +316,7 @@ fn missing_character_handled_correctly() {
 #[test]
 fn missing_character_handled_correctly() {
     let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
-    assert!(bmfont.parse("Ř").is_empty());
+    assert_eq!(bmfont.parse("Ř").count(), 0);
 }
 
 #[cfg(feature = "parse-error")]
@@ -332,5 +333,5 @@ fn unsupported_character_handled_correctly() {
 #[test]
 fn unsupported_character_handled_correctly() {
     let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
-    assert!(bmfont.parse("𐃌").is_empty());
+    assert_eq!(bmfont.parse("𐃌").count(), 0);
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,7 +13,12 @@ fn create_bmfont(ordinate_orientation: OrdinateOrientation) -> BMFont {
 }
 
 fn parse(s: &str, ordinate_orientation: OrdinateOrientation) -> Vec<CharPosition> {
-    create_bmfont(ordinate_orientation).parse(s).unwrap()
+    let font = create_bmfont(ordinate_orientation).parse(s);
+
+    #[cfg(feature = "parse-error")]
+    let font = font.unwrap();
+
+    font
 }
 
 fn assert_rect_equal(rect: &Rect, another_rect: &Rect) {
@@ -296,6 +301,7 @@ fn letters_with_kerning_for_bottom_to_top_orientation_parsed_correctly() {
     assert_letters_with_kerning_parsed_correctly(OrdinateOrientation::BottomToTop, [-2, -2, -3]);
 }
 
+#[cfg(feature = "parse-error")]
 #[test]
 fn missing_character_handled_correctly() {
     let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
@@ -305,6 +311,14 @@ fn missing_character_handled_correctly() {
     }
 }
 
+#[cfg(not(feature = "parse-error"))]
+#[test]
+fn missing_character_handled_correctly() {
+    let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
+    assert!(bmfont.parse("Ř").is_empty());
+}
+
+#[cfg(feature = "parse-error")]
 #[test]
 fn unsupported_character_handled_correctly() {
     let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
@@ -312,4 +326,11 @@ fn unsupported_character_handled_correctly() {
         Err(error) => assert_eq!(error.unsupported_characters, vec!['𐃌']),
         Ok(_) => panic!(),
     }
+}
+
+#[cfg(not(feature = "parse-error"))]
+#[test]
+fn unsupported_character_handled_correctly() {
+    let bmfont = create_bmfont(OrdinateOrientation::TopToBottom);
+    assert!(bmfont.parse("𐃌").is_empty());
 }


### PR DESCRIPTION
I took a stab at improving the performance of this library.
- Added benchmarks for parse operation
- Converted `Vec` return types to `Iterator` implementations
- Added some documentation
- Changed "parse errors" to be a Cargo feature; I wanted different behavior for my use cases plus this sped things up a bit
- Changed to Rust 2018 edition because of some tooling issue; could probably resolve that but it is 2021 anyways

Because of the new cargo feature it may be helpful to run both `cargo test` and also `cargo test --no-default-features` in order to run the tests for both paths.

To run the benchmarks, run `cargo bench` from the root, or just cherry-pick `e9c43f1` onto some other branch you might want to bench. Each of the things on this branch is separable (with some work) and individually improves performance.

## Sample
- `Winner: Attackgoat`: Before=**2.9**us After=**112**ns
- `Van Gogh my earlo...[~520 CHARS]`: Before=**82**us After=**3.6**us

This is the perf graph for `Winner: Attackgoat`; red is this PR and blue is the `master` branch with `e9c43f1`:

![image](https://user-images.githubusercontent.com/7445438/105622311-bf0e5b00-5dcd-11eb-9cc2-8fa6e9a8c626.png)

## TL;DR:

Criterion says this is -95% improvement.